### PR TITLE
Update checkout action version in SLSA workflow

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -31,7 +31,7 @@ jobs:
       tree-state: ${{ steps.ldflags.outputs.tree-state }}
     steps:
       - id: checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.3.4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           fetch-depth: 0
       - id: ldflags


### PR DESCRIPTION
Used full SHA grabbed from https://github.com/actions/checkout/releases by clicking and copying the sha in left side